### PR TITLE
fix(auth): add gmail.readonly scope to Google OAuth provider

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -13,6 +13,7 @@ export const auth = betterAuth({
       clientId: env.server.GOOGLE_CLIENT_ID,
       clientSecret: env.server.GOOGLE_CLIENT_SECRET,
       prompt: "select_account",
+      scope: ["openid", "email", "profile", "https://www.googleapis.com/auth/gmail.readonly"],
     },
   },
 });


### PR DESCRIPTION
### Description

**Summary**  
Added the Gmail readonly scope to the Google provider configuration in `lib/auth.ts` so that Gmail access is properly requested during OAuth.

**Changes**
- Updated `google` provider config in `better-auth` setup to include:
  ```ts
  scope: ["openid", "email", "profile", "https://www.googleapis.com/auth/gmail.readonly"]
  ```
- Verified Gmail permission prompt appears after re-authentication.

**Closes:** #9
