### PR TITLE
fix(0.8.0): harden auth proxy matching and Google OAuth tokens

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -12,7 +12,8 @@ export const auth = betterAuth({
     google: {
       clientId: env.server.GOOGLE_CLIENT_ID,
       clientSecret: env.server.GOOGLE_CLIENT_SECRET,
-      prompt: "select_account",
+      accessType: "offline",
+      prompt: "select_account consent",
       scope: ["openid", "email", "profile", "https://www.googleapis.com/auth/gmail.readonly"],
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiwis-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiwis-web",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@prisma/client": "^6.17.1",
         "@radix-ui/react-avatar": "^1.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiwis-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "homepage": "https://kiwis.club",
   "scripts": {

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,25 +4,26 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 
 export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const isApiRequest = pathname.startsWith("/api");
+
   const session = await auth.api.getSession({
     headers: request.headers,
   });
 
-  const isApi = request.nextUrl.pathname.startsWith("/api");
-
   if (!session) {
-    if (isApi) {
-      // API request → return 401 Unauthorized JSON
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Page request → redirect browser to home page
-    return NextResponse.redirect(new URL("/", request.url));
+    return isApiRequest
+      ? NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      : NextResponse.redirect(new URL("/", request.url));
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/api/:path*", "/dashboard", "/profile"],
+  matcher: [
+    "/api/((?!auth).*)", // all api except auth
+    "/dashboard",
+    "/profile",
+  ],
 };


### PR DESCRIPTION
Improves authentication reliability on the 0.8.0 release line.

- Refines proxy matcher to correctly exclude `/api/auth`.
- Standardizes unauthorized handling for API and page requests.
- Updates Google OAuth config to request offline access and explicit consent,
  ensuring refresh tokens for long-lived Gmail read access.

No behavior changes for authenticated users.