### PR TITLE
refactor(api): centralize API error handling

### DIFF
--- a/app/api/payments/[id]/route.ts
+++ b/app/api/payments/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { handleApiError } from "@/lib/api/handleApiError";
 import prisma from "@/lib/prisma";
 import { requireSession } from "@/lib/requireSession";
 
@@ -36,12 +37,6 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
 
     return NextResponse.json(payment);
   } catch (err: unknown) {
-    console.error("GET /api/payments/[id] error:", err);
-
-    if (err instanceof Response) return err;
-
-    const message = err instanceof Error && err.message ? err.message : "Internal server error";
-
-    return NextResponse.json({ error: message }, { status: 500 });
+    return handleApiError(err, "GET /api/payments/[id]");
   }
 }

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import type { Prisma } from "@/generated/prisma";
 import { PaymentStatus, Recurrence } from "@/generated/prisma";
+import { handleApiError } from "@/lib/api/handleApiError";
 import prisma from "@/lib/prisma";
 import { requireSession } from "@/lib/requireSession";
 import { parseEnum } from "@/utils/enum";
@@ -54,12 +55,6 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ page, limit, total, data });
   } catch (err: unknown) {
-    console.error("GET /api/payments error:", err);
-
-    if (err instanceof Response) return err;
-
-    const message = err instanceof Error && err.message ? err.message : "Internal server error";
-
-    return NextResponse.json({ error: message }, { status: 500 });
+    return handleApiError(err, "GET /api/payments");
   }
 }

--- a/lib/api/handleApiError.ts
+++ b/lib/api/handleApiError.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+type ErrorWithStatus = {
+  status?: number;
+};
+
+export function handleApiError(err: unknown, label: string) {
+  console.error(label, err);
+
+  if (err instanceof Response) return err;
+
+  const message = err instanceof Error && err.message ? err.message : "Internal server error";
+
+  const status =
+    typeof (err as ErrorWithStatus)?.status === "number" ? (err as ErrorWithStatus).status : 500;
+
+  return NextResponse.json({ error: message }, { status });
+}

--- a/lib/requireSession.ts
+++ b/lib/requireSession.ts
@@ -8,17 +8,14 @@ export type BetterAuthSession = {
   user: User;
 } | null;
 
-export type AppSession = {
-  session: Session;
-  user: User;
-};
-
 /**
  * Extracts and validates session from any request.
  * Works for API routes, middleware, or server components.
  * Throws if session is missing.
  */
-export async function requireSession(req: Request | NextRequest): Promise<AppSession> {
+export async function requireSession(
+  req: Request | NextRequest
+): Promise<{ session: Session; user: User }> {
   // Extract headers
   const headers = "headers" in req ? req.headers : new Headers();
 


### PR DESCRIPTION
- Extract handleApiError utility to standardize error logging and responses.
- Simplify API routes by delegating error serialization to a shared helper.
- Preserve HTTP status codes when available and default to 500 otherwise.