### PR TITLE
chore(devops): add PM2 production setup with Makefile integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,69 @@
 # Makefile for Kiwis Web
 
-# Variables
-NPM = npm
-NODE_MODULES = node_modules
+# ---------
+# Binaries
+# ---------
+PM2 := pm2
+NPM := npm
+NODE_MODULES := node_modules
 
-# helper function to check prerequisites
+# ---------------------------------
+# Prerequisite checks (reusable)
+# ---------------------------------
+
+# Ensure Node.js and npm exist
 define check_prereqs
-	@command -v node >/dev/null 2>&1 || { echo "❌ Node.js is not installed. Please install it first."; exit 1; }
-	@command -v npm >/dev/null 2>&1 || { echo "❌ npm is not installed. Please install it first."; exit 1; }
+	@command -v node >/dev/null 2>&1 || { echo "Node.js not installed"; exit 1; }
+	@command -v $(NPM) >/dev/null 2>&1 || { echo "npm not installed"; exit 1; }
 endef
 
-# check if node_modules exists
+# Ensure dependencies are installed
 define check_node_modules
 	@if [ ! -d "$(NODE_MODULES)" ]; then \
-		echo "⚠️  node_modules not found. Run 'make install' first."; \
+		echo "node_modules not found. Run 'make install' first."; \
 		exit 1; \
 	fi
 endef
 
-.PHONY: help install dev build start lint format format-check check-types
+# Ensure PM2 is available
+define check_pm2
+	@command -v $(PM2) >/dev/null 2>&1 || { echo "PM2 not installed"; exit 1; }
+endef
 
+# -----------------------------
+# Phony targets
+# -----------------------------
+.PHONY: \
+	help install dev build start lint prepare \
+	format format-check check-types \
+	pm2-start pm2-stop pm2-restart pm2-delete
+
+# -----------------------------
+# Help
+# -----------------------------
 help:
 	@echo "Available commands:"
+	@echo ""
 	@echo "  make install        - install dependencies"
 	@echo "  make dev            - start development server (Next.js + Turbopack)"
 	@echo "  make build          - build project for production"
 	@echo "  make start          - start production server"
+	@echo ""
 	@echo "  make lint           - run ESLint"
+	@echo "  make prepare        - setup git hooks (husky)"
 	@echo "  make format         - format code with Prettier"
 	@echo "  make format-check   - check formatting with Prettier"
 	@echo "  make check-types    - run TypeScript type check"
+	@echo ""
+	@echo "  make pm2-start      - start app using PM2"
+	@echo "  make pm2-stop       - stop app using PM2"
+	@echo "  make pm2-restart    - restart app using PM2"
+	@echo "  make pm2-delete     - remove app from PM2"
+	@echo ""
 
+# -----------------------------
+# Core commands
+# -----------------------------
 install:
 	$(call check_prereqs)
 	$(NPM) install
@@ -55,6 +88,10 @@ lint:
 	$(call check_node_modules)
 	$(NPM) run lint
 
+prepare:
+	$(call check_prereqs)
+	$(NPM) run prepare
+
 format:
 	$(call check_prereqs)
 	$(call check_node_modules)
@@ -69,3 +106,27 @@ check-types:
 	$(call check_prereqs)
 	$(call check_node_modules)
 	$(NPM) run check-types
+
+# -----------------------------
+# PM2 management
+# -----------------------------
+pm2-start:
+	$(call check_prereqs)
+	$(call check_pm2)
+	$(NPM) run build
+	$(NPM) run pm2:start
+
+pm2-stop:
+	$(call check_prereqs)
+	$(call check_pm2)
+	$(NPM) run pm2:stop
+
+pm2-restart:
+	$(call check_prereqs)
+	$(call check_pm2)
+	$(NPM) run pm2:restart
+
+pm2-delete:
+	$(call check_prereqs)
+	$(call check_pm2)
+	$(NPM) run pm2:delete

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  apps: [
+    {
+      name: "kiwis-web",
+      script: "./node_modules/.bin/next",
+      args: "start",
+      cwd: __dirname,
+      instances: "max",
+      exec_mode: "cluster",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3000,
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "prepare": "husky",
     "format": "prettier . --write --cache",
     "format:check": "prettier . --check",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "pm2:start": "pm2 start ecosystem.config.js",
+    "pm2:stop": "pm2 stop ecosystem.config.js",
+    "pm2:restart": "pm2 restart ecosystem.config.js",
+    "pm2:delete": "pm2 delete ecosystem.config.js"
   },
   "dependencies": {
     "@prisma/client": "^6.17.1",


### PR DESCRIPTION
- Add PM2 ecosystem config for Next.js production
- Extend Makefile with PM2 management commands
- Enforce build step before PM2 start
- Improve prerequisite checks and help output